### PR TITLE
Add some new features

### DIFF
--- a/org-clock-today.el
+++ b/org-clock-today.el
@@ -48,16 +48,15 @@
 
 (defun org-clock-today--total-minutes ()
   "Return the total minutes."
-  (with-current-buffer (org-clock-is-active)
-    (let* ((current-sum (org-clock-sum-today))
-           (open-time-difference (time-subtract
-                                  (float-time)
-                                  (float-time org-clock-start-time)))
-           (open-seconds (time-to-seconds open-time-difference))
-           (open-minutes (/ open-seconds 60))
-           (total-minutes (+ current-sum
-                             open-minutes)))
-      (org-minutes-to-clocksum-string total-minutes))))
+  (let* ((current-sum (org-clock-sum-today))
+         (open-time-difference (time-subtract
+                                (float-time)
+                                (float-time org-clock-start-time)))
+         (open-seconds (time-to-seconds open-time-difference))
+         (open-minutes (/ open-seconds 60))
+         (total-minutes (+ current-sum
+                           open-minutes)))
+    (org-minutes-to-clocksum-string total-minutes)))
 
 (defun org-clock-today-toggle-count-subtree ()
   "Toggle count total minutes in subtree or buffer."
@@ -69,16 +68,18 @@
   "Calculate the total clocked time of today and update the mode line."
   (setq org-clock-today-string
         (if (org-clock-is-active)
-            (concat
-             " "
-             (when org-clock-today-current-item
-               (concat
-                (save-excursion
-                  (save-restriction
-                    (org-narrow-to-subtree)
-                    (org-clock-today--total-minutes)))
-                "|"))
-             (org-clock-today--total-minutes))
+            (with-current-buffer (org-clock-is-active)
+              (concat
+               " "
+               (when org-clock-today-current-item
+                 (concat
+                  (save-excursion
+                    (save-restriction
+                      (goto-char org-clock-marker)
+                      (org-narrow-to-subtree)
+                      (org-clock-today--total-minutes)))
+                  " "))
+               (org-clock-today--total-minutes)))
           ""))
   (force-mode-line-update))
 

--- a/org-clock-today.el
+++ b/org-clock-today.el
@@ -1,10 +1,12 @@
-;;; org-clock-today.el --- Show the total clocked time of the current day in the mode line -*- lexical-binding: t -*-
+;;; org-clock-today.el --- Show total clocked time of the current day in the mode line -*- lexical-binding: t -*-
 
 ;; Copyright © 2016 Tijs Mallaerts
 ;;
 ;; Author: Tijs Mallaerts <tijs.mallaerts@gmail.com>
 
 ;; Package-Requires: ((emacs "25"))
+;; Version: 1.9.0
+;; URL: https://github.com/mallt/org-clock-today-mode
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -60,7 +62,7 @@
                            open-minutes)))
     (org-duration-from-minutes total-minutes)))
 
-(defun org-clcok-today--display-default ()
+(defun org-clock-today--display-default ()
   "Default function to return string for displaying clocks."
   (concat
    " "
@@ -68,7 +70,7 @@
      (concat org-clock-today--subtree-time " "))
    org-clock-today--buffer-time))
 
-(defcustom org-clock-today-display-format #'org-clcok-today--display-default
+(defcustom org-clock-today-display-format #'org-clock-today--display-default
   "Function to call when building string for mode-line."
   :type '(choice
           (const :tag "Do nothing" ignore)

--- a/org-clock-today.el
+++ b/org-clock-today.el
@@ -47,6 +47,7 @@
 (defvar org-clock-today-timer nil)
 
 (defvar org-clock-today--subtree nil)
+(defvar org-clock-today--buffer nil)
 (defun org-clock-today--total-minutes ()
   "Return the total minutes."
   (let* ((current-sum (org-clock-sum-today))
@@ -65,23 +66,30 @@
   (setq org-clock-today-current-item (not org-clock-today-current-item))
   (org-clock-today-update-mode-line))
 
+(defun org-clcok-today--display-default ()
+  "Default function to return string for displaying clocks."
+  (concat
+   " "
+   (when org-clock-today-current-item
+     (concat org-clock-today--subtree " "))
+   org-clock-today--buffer))
+
+(defvar org-clock-today-display-format #'org-clcok-today--display-default)
 (defun org-clock-today-update-mode-line ()
   "Calculate the total clocked time of today and update the mode line."
   (setq org-clock-today-string
         (if (org-clock-is-active)
             (with-current-buffer (org-clock-is-active)
-              (concat
-               " "
-               (when org-clock-today-current-item
-                 (concat
-                  (save-excursion
-                    (save-restriction
-                      (goto-char org-clock-marker)
-                      (org-narrow-to-subtree)
-                      (setq org-clock-today--subtree
-                            (org-clock-today--total-minutes))))
-                  " "))
-               (org-clock-today--total-minutes)))
+              (when org-clock-today-current-item
+                (save-excursion
+                  (save-restriction
+                    (goto-char org-clock-marker)
+                    (org-narrow-to-subtree)
+                    (setq org-clock-today--subtree
+                          (org-clock-today--total-minutes)))))
+              (setq org-clock-today--buffer
+                    (org-clock-today--total-minutes))
+              (funcall org-clock-today-display-format))
           ""))
   (force-mode-line-update))
 

--- a/org-clock-today.el
+++ b/org-clock-today.el
@@ -56,7 +56,7 @@
          (open-minutes (/ open-seconds 60))
          (total-minutes (+ current-sum
                            open-minutes)))
-    (org-minutes-to-clocksum-string total-minutes)))
+    (org-duration-from-minutes total-minutes)))
 
 (defun org-clock-today-toggle-count-subtree ()
   "Toggle count total minutes in subtree or buffer."

--- a/org-clock-today.el
+++ b/org-clock-today.el
@@ -57,7 +57,7 @@
            (open-minutes (/ open-seconds 60))
            (total-minutes (+ current-sum
                              open-minutes)))
-      (concat " " (org-minutes-to-clocksum-string total-minutes)))))
+      (org-minutes-to-clocksum-string total-minutes))))
 
 (defun org-clock-today-toggle-count-subtree ()
   "Toggle count total minutes in subtree or buffer."
@@ -69,12 +69,16 @@
   "Calculate the total clocked time of today and update the mode line."
   (setq org-clock-today-string
         (if (org-clock-is-active)
-            (if org-clock-today-current-item
+            (concat
+             " "
+             (when org-clock-today-current-item
+               (concat
                 (save-excursion
                   (save-restriction
                     (org-narrow-to-subtree)
                     (org-clock-today--total-minutes)))
-              (org-clock-today--total-minutes))
+                "|"))
+             (org-clock-today--total-minutes))
           ""))
   (force-mode-line-update))
 

--- a/org-clock-today.el
+++ b/org-clock-today.el
@@ -5,7 +5,7 @@
 ;; Author: Tijs Mallaerts <tijs.mallaerts@gmail.com>
 
 ;; Package-Requires: ((emacs "25"))
-;; Version: 1.9.0
+;; Version: 1.9.9
 ;; URL: https://github.com/mallt/org-clock-today-mode
 
 ;; This program is free software: you can redistribute it and/or modify
@@ -40,16 +40,16 @@
   :type 'boolean
   :group 'org-clock-today)
 
-(defcustom org-clock-today-current-item nil
-  "If non-nil, count total minutes of the current subtree."
+(defcustom org-clock-today-count-subtree nil
+  "If non-nil, count total minutes of the current subtree as well."
   :type 'boolean
   :group 'org-clock-today)
 
 (defvar org-clock-today--string "")
 (defvar org-clock-today--timer nil)
-
 (defvar org-clock-today--subtree-time nil)
 (defvar org-clock-today--buffer-time nil)
+
 (defun org-clock-today--total-minutes ()
   "Return the total minutes."
   (let* ((current-sum (org-clock-sum-today))
@@ -66,7 +66,7 @@
   "Default function to return string for displaying clocks."
   (concat
    " "
-   (when org-clock-today-current-item
+   (when org-clock-today-count-subtree
      (concat org-clock-today--subtree-time " "))
    org-clock-today--buffer-time))
 
@@ -81,7 +81,7 @@
   (setq org-clock-today--string
         (if (org-clock-is-active)
             (with-current-buffer (org-clock-is-active)
-              (when org-clock-today-current-item
+              (when org-clock-today-count-subtree
                 (save-excursion
                   (save-restriction
                     (goto-char org-clock-marker)
@@ -113,7 +113,9 @@
 (defun org-clock-today-toggle-count-subtree ()
   "Toggle count total minutes in subtree or buffer."
   (interactive)
-  (setq org-clock-today-current-item (not org-clock-today-current-item))
+  (setq org-clock-today-count-subtree (not org-clock-today-count-subtree))
+  (unless org-clock-today-count-subtree
+    (setq org-clock-today--subtree-time nil))
   (org-clock-today--update-mode-line))
 
 ;;;###autoload

--- a/org-clock-today.el
+++ b/org-clock-today.el
@@ -1,11 +1,11 @@
 ;;; org-clock-today.el --- Show total clocked time of the current day in the mode line -*- lexical-binding: t -*-
 
-;; Copyright © 2016 Tijs Mallaerts
+;; Copyright © 2016-2019 Tijs Mallaerts
 ;;
 ;; Author: Tijs Mallaerts <tijs.mallaerts@gmail.com>
 
 ;; Package-Requires: ((emacs "25"))
-;; Version: 1.9.9
+;; Version: 0.0.2
 ;; URL: https://github.com/mallt/org-clock-today-mode
 
 ;; This program is free software: you can redistribute it and/or modify
@@ -45,10 +45,10 @@
   :type 'boolean
   :group 'org-clock-today)
 
-(defvar org-clock-today--string "")
+(defvar org-clock-today-string "" "The lighter.")
+(defvar org-clock-today-subtree-time nil "Clock count extracted from subtree.")
+(defvar org-clock-today-buffer-time nil "Clock count extracted from buffer.")
 (defvar org-clock-today--timer nil)
-(defvar org-clock-today--subtree-time nil)
-(defvar org-clock-today--buffer-time nil)
 
 (defun org-clock-today--total-minutes ()
   "Return the total minutes."
@@ -67,8 +67,8 @@
   (concat
    " "
    (when org-clock-today-count-subtree
-     (concat org-clock-today--subtree-time " "))
-   org-clock-today--buffer-time))
+     (concat org-clock-today-subtree-time " "))
+   org-clock-today-buffer-time))
 
 (defcustom org-clock-today-display-format #'org-clock-today--display-default
   "Function to call when building string for mode-line."
@@ -78,7 +78,7 @@
 
 (defun org-clock-today--update-mode-line ()
   "Calculate the total clocked time of today and update the mode line."
-  (setq org-clock-today--string
+  (setq org-clock-today-string
         (if (org-clock-is-active)
             (with-current-buffer (org-clock-is-active)
               (when org-clock-today-count-subtree
@@ -86,9 +86,9 @@
                   (save-restriction
                     (goto-char org-clock-marker)
                     (org-narrow-to-subtree)
-                    (setq org-clock-today--subtree-time
+                    (setq org-clock-today-subtree-time
                           (org-clock-today--total-minutes)))))
-              (setq org-clock-today--buffer-time
+              (setq org-clock-today-buffer-time
                     (org-clock-today--total-minutes))
               (funcall org-clock-today-display-format))
           ""))
@@ -115,13 +115,13 @@
   (interactive)
   (setq org-clock-today-count-subtree (not org-clock-today-count-subtree))
   (unless org-clock-today-count-subtree
-    (setq org-clock-today--subtree-time nil))
+    (setq org-clock-today-subtree-time nil))
   (org-clock-today--update-mode-line))
 
 ;;;###autoload
 (define-minor-mode org-clock-today-mode
   "Minor mode to show the total clocked time of the current day in the mode line."
-  :lighter org-clock-today--string
+  :lighter org-clock-today-string
   :global t
   (if org-clock-today-mode
       (progn

--- a/org-clock-today.el
+++ b/org-clock-today.el
@@ -46,6 +46,7 @@
 (defvar org-clock-today-string "")
 (defvar org-clock-today-timer nil)
 
+(defvar org-clock-today--subtree nil)
 (defun org-clock-today--total-minutes ()
   "Return the total minutes."
   (let* ((current-sum (org-clock-sum-today))
@@ -77,7 +78,8 @@
                     (save-restriction
                       (goto-char org-clock-marker)
                       (org-narrow-to-subtree)
-                      (org-clock-today--total-minutes)))
+                      (setq org-clock-today--subtree
+                            (org-clock-today--total-minutes))))
                   " "))
                (org-clock-today--total-minutes)))
           ""))


### PR DESCRIPTION
Hi!

I love this package and tried to add new features. Also I changed some parts in this package to pass the validation of the current MELPA adoption by `checkdoc` and `package-lint-current-buffer`.

Feature 1:
- Supporting to count today's effort within a specific subtree.
- Providing two private variables `org-clock-today--subtree-time` and `org-clock-today--buffer-time`. `org-clock-today--buffer-time` stores the normal count results that the package previously provided. And `org-clock-today--subtree-time` stores the count results limited to the focused subtree.
- Providing a flag to use `org-clock-today--subtree-time` or not.
- Providing a toggle to change the flag as `org-clock-today-toggle-count-subtree`.

Feature 2:
- Supporting to customize displaying format on the mode-line
- Providing custom variable to change the format as `org-clock-today-display-format`
- Providing the default function as `org-clcok-today--display-default`

Any questions and suggestions are welcome!

Best,
Takaaki